### PR TITLE
Self-reference using `npm link`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A remark plugin to handle version bumps for changelogs adhering to Keep a Changelog",
   "main": "index.js",
   "scripts": {
+    "prepare": "npm link --ignore-scripts && npm link $npm_package_name",
     "test": "jasmine",
     "preversion": "./version-scripts/run-preversion",
     "version": "./version-scripts/run-version",


### PR DESCRIPTION
Add a prepare script to self-reference the package so it can be used by remark during version bumps.